### PR TITLE
Add link href and logo alt text test

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -7,3 +7,11 @@ test('renders learn react link', () => {
   const linkElement = screen.getByText(/learn react/i);
   expect(linkElement).toBeInTheDocument();
 });
+
+test('link has correct href and logo alt text', () => {
+  render(<App />);
+  const linkElement = screen.getByRole('link', { name: /learn react/i });
+  expect(linkElement).toHaveAttribute('href', 'https://reactjs.org');
+  const logoImg = screen.getByRole('img', { name: /logo/i });
+  expect(logoImg).toHaveAttribute('alt', 'logo');
+});


### PR DESCRIPTION
## Summary
- ensure the React link points to the docs
- check that the logo has the proper alt text

## Testing
- `yarn test --watchAll=false` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_685b3ffb14048333a77383cccdf7f4ab